### PR TITLE
docs(public-launch): soften star-focused copy

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -85,9 +85,9 @@ OK: workflow-skill-router passed validation
 - [Template Skill Catalog](examples/template-skill-catalog): the matching route catalog for the template package.
 - [Template manifest](downloads/workflow-skill-router-template-manifest.md): included skill folders, excluded private skill count, and sanitization summary.
 
-## Why Star This
+## Project Roadmap And Community
 
-Star the repo if you want to track a practical pattern for:
+Follow releases or watch the repo to track work on:
 
 - keeping multi-skill agents out of context overload,
 - benchmarking routing decisions with repeatable scenarios,

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ OK: workflow-skill-router passed validation
 - [Template Skill Catalog](examples/template-skill-catalog): the matching route catalog for the template package.
 - [Template manifest](downloads/workflow-skill-router-template-manifest.md): included skill folders, excluded private skill count, and sanitization summary.
 
-## Why Star This
+## Project Roadmap And Community
 
-Star the repo if you want to track a practical pattern for:
+Follow releases or watch the repo to track work on:
 
 - keeping multi-skill agents out of context overload,
 - benchmarking routing decisions with repeatable scenarios,

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -85,9 +85,9 @@ OK: workflow-skill-router passed validation
 - [Template Skill Catalog](examples/template-skill-catalog)：對應範本包的 routing catalog。
 - [Template manifest](downloads/workflow-skill-router-template-manifest.md)：列出包含的 skill folders、排除的 private skill 數量與 sanitization summary。
 
-## 為什麼值得 Star
+## 專案 Roadmap 與社群方向
 
-如果你想追蹤以下方向，歡迎 star：
+你可以透過 release 或 watch 追蹤以下方向：
 
 - 讓多技能 Agent 避免 context overload。
 - 用 benchmark scenarios 評估 routing 決策。

--- a/site/src/components/DocsPageSidebar.astro
+++ b/site/src/components/DocsPageSidebar.astro
@@ -10,16 +10,16 @@ const repoUrl = 'https://github.com/eric861129/Workflow-skill-router';
 const copy = isZh
   ? {
       eyebrow: '開源分享',
-      title: '覺得這個 pattern 有用？',
-      body: 'Star repo，或下載 template package 直接試一次 routing。',
-      star: 'Star on GitHub',
+      title: '查看開源專案',
+      body: '打開 repo、下載 template package，或直接試一次 routing。',
+      star: '查看 GitHub',
       download: '下載 template',
     }
   : {
       eyebrow: 'Open source',
-      title: 'Useful pattern?',
-      body: 'Star the repo, or download the template package and try routing on your own agent.',
-      star: 'Star on GitHub',
+      title: 'Explore the project',
+      body: 'Open the repo, download the template package, or try routing on your own agent.',
+      star: 'View on GitHub',
       download: 'Download template',
     };
 ---

--- a/site/src/components/HomeLanding.astro
+++ b/site/src/components/HomeLanding.astro
@@ -18,7 +18,7 @@ const text = {
   en: {
     nav: ['Why it works', 'Examples', 'Proof'],
     navLinks: ['#why-it-works', '#examples', '#validator'],
-    star: 'Star on GitHub',
+    star: 'View on GitHub',
     quickstart: 'Start in 30 seconds',
     downloadBlank: 'Download blank package',
     download: 'Download template',
@@ -104,14 +104,14 @@ python scripts/evaluate-routing.py \\
   --strict
 
 python -m unittest discover -s tests`,
-    finalTitle: 'Make skill routing a pattern people can star, fork, and reuse',
+    finalTitle: 'Make skill routing a reusable open-source pattern',
     finalCopy:
-      'Open the repository, inspect the starter, and star it if the pattern helps your AI agent work with less chaos.',
+      'Open the repository, inspect the starter, and follow releases if the pattern fits your agent workflow.',
   },
   'zh-tw': {
     nav: ['為什麼有效', '範例', '驗證'],
     navLinks: ['#why-it-works', '#examples', '#validator'],
-    star: '到 GitHub 給星星',
+    star: '查看 GitHub',
     quickstart: '30 秒開始',
     downloadBlank: '下載空白套件',
     download: '下載範本',
@@ -197,9 +197,9 @@ python scripts/evaluate-routing.py \\
   --strict
 
 python -m unittest discover -s tests`,
-    finalTitle: '把 skill routing 變成值得 star、fork、重用的 pattern',
+    finalTitle: '把 skill routing 打磨成可重用的開源 pattern',
     finalCopy:
-      '打開 GitHub repo，檢查 starter。如果這個 pattern 能讓你的 AI Agent 工作更清楚，歡迎給它一顆星。',
+      '打開 GitHub repo，檢查 starter。如果這個 pattern 適合你的 Agent workflow，可以透過 releases 追蹤後續更新。',
   },
 }[locale];
 
@@ -214,7 +214,7 @@ const demoText = isZh
       copied: '已複製',
       copyInstall: '複製安裝指令',
       installCopied: '指令已複製',
-      star: '覺得有用就 Star',
+      star: '查看 GitHub repo',
       template: '查看 Template Skill Catalog',
     }
   : {
@@ -227,7 +227,7 @@ const demoText = isZh
       copied: 'Copied',
       copyInstall: 'Copy install command',
       installCopied: 'Install command copied',
-      star: 'Star if this helps',
+      star: 'View GitHub repo',
       template: 'View Template Skill Catalog',
     };
 
@@ -333,7 +333,7 @@ const initialDemo = routeDemoScenarios[0];
       </button>
       <a class="wsr-nav-star" href={repoUrl} target="_blank" rel="noreferrer" aria-label={text.star}>
         <span class="wsr-star-full">{text.star}</span>
-        <span class="wsr-star-short">Star</span>
+        <span class="wsr-star-short">GitHub</span>
       </a>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- reduce active GitHub star CTA wording across README and site copy
- replace star-focused prompts with repository, release, and open-source project language
- keep passive stars badge only as social proof

## Validation
- python scripts\\audit-public-readiness.py .
- python -m unittest discover -s tests
- rg star CTA scan: no active star prompts remain
- rg mojibake scan: no matches