### PR TITLE
docs(release): finalize beta.2 changelog metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to Workflow Skill Router are documented here.
 
 ## Unreleased
 
-### Fixed
-
-- Prioritized immutable release installs for normal Plugin and Skill-only users, while keeping contributor checkout instructions separate.
-- Aligned public beta copy with the released 12-tool, four-local-ready Runtime profile and reviewed 36-attempt evaluation evidence.
-- Pointed Plugin metadata directly at the canonical documentation URL and clarified the beta roadmap status.
-
 ## 2.0.0-beta.2
 
 ### Added
@@ -23,11 +17,14 @@ All notable changes to Workflow Skill Router are documented here.
 - Prevented linked Profile directories and linked install sources from writing outside the Router data directory.
 - Preserved beta.1 explicit Skill intent and idempotent replay when migration `0005` adds Profile planning fields.
 - Separated beta.1 real-model evidence from beta.2 Profile claims across the homepage, documentation, release notes, and Blog.
+- Aligned public beta copy with the released 12-tool, four-local-ready Runtime profile and reviewed 36-attempt evaluation evidence.
 
 ### Changed
 
 - Clarified that Skill-only Profile loading requires Host filesystem access and remains advisory `skill-only-fallback`.
 - Kept the public MCP surface at twelve tools and the bundled local-ready surface at four tools.
+- Prioritized immutable release installs for normal Plugin and Skill-only users while keeping contributor checkout instructions separate.
+- Pointed Plugin metadata directly at the canonical documentation URL and clarified the beta roadmap status.
 
 ## 2.0.0-beta.1
 

--- a/site/src/content/docs/contributing/roadmap.md
+++ b/site/src/content/docs/contributing/roadmap.md
@@ -21,7 +21,7 @@ description: Track evidence-backed milestones from alpha to GA.
 
 - [x] Add Personal and Workspace Routing Profiles with packaged examples
 - [x] Close junction, symlink, migration, and evidence-labeling gaps
-- [ ] Pass Windows, macOS, and Linux CI on the frozen source revision
+- [x] Pass Windows, macOS, and Linux CI on the frozen source revision
 - [ ] Publish the prerelease and move only `latest-v2`
 - [x] Completed the corrected 36-attempt Behavior smoke with explicit quota authorization
 - [x] Reviewed paired results and published only attested, sanitized evidence

--- a/site/src/content/docs/zh-tw/contributing/roadmap.md
+++ b/site/src/content/docs/zh-tw/contributing/roadmap.md
@@ -21,7 +21,7 @@ description: 以可驗證的證據，追蹤從 alpha 到 GA 的里程碑。
 
 - [x] 加入 Personal 與 Workspace Routing Profiles 及套件範例
 - [x] 修正 junction、symlink、migration 與 evidence labeling 缺口
-- [ ] 讓凍結 source revision 的 Windows、macOS、Linux CI 全部通過
+- [x] 讓凍結 source revision 的 Windows、macOS、Linux CI 全部通過
 - [ ] 發布 prerelease，且只移動 `latest-v2`
 - [x] 已在明確 quota authorization 下完成修正後的 36-attempt Behavior smoke
 - [x] 已審查 paired results，只發布有 attestation 且已去識別化的 evidence


### PR DESCRIPTION
## Summary

- move release copy already included in beta.2 out of `Unreleased` and into the `2.0.0-beta.2` changelog entry
- record the completed Windows, macOS, and Linux CI gate in both roadmap languages

## Verification

- [x] 27 release/documentation contract tests
- [x] Markdown link check
- [x] 60-page Astro build
- [x] `git diff --check`

The prerelease publication checkbox remains open until the GitHub Release workflow succeeds.