### PR TITLE
docs(release): mark beta.2 milestone complete

### DIFF
--- a/site/src/content/docs/contributing/roadmap.md
+++ b/site/src/content/docs/contributing/roadmap.md
@@ -17,12 +17,12 @@ description: Track evidence-backed milestones from alpha to GA.
 
 - [x] Published the immutable `v2.0.0-beta.1` marketplace snapshot
 
-## Beta 2.0.0-beta.2 — release candidate
+## Beta 2.0.0-beta.2 — completed
 
 - [x] Add Personal and Workspace Routing Profiles with packaged examples
 - [x] Close junction, symlink, migration, and evidence-labeling gaps
 - [x] Pass Windows, macOS, and Linux CI on the frozen source revision
-- [ ] Publish the prerelease and move only `latest-v2`
+- [x] Publish the prerelease and move only `latest-v2`
 - [x] Completed the corrected 36-attempt Behavior smoke with explicit quota authorization
 - [x] Reviewed paired results and published only attested, sanitized evidence
 - [x] Validated Plugin and Skill-only release-archive contracts on Windows, macOS, and Linux

--- a/site/src/content/docs/zh-tw/contributing/roadmap.md
+++ b/site/src/content/docs/zh-tw/contributing/roadmap.md
@@ -17,12 +17,12 @@ description: 以可驗證的證據，追蹤從 alpha 到 GA 的里程碑。
 
 - [x] 已發布不可變的 `v2.0.0-beta.1` marketplace snapshot
 
-## Beta 2.0.0-beta.2 — release candidate
+## Beta 2.0.0-beta.2 — 已完成
 
 - [x] 加入 Personal 與 Workspace Routing Profiles 及套件範例
 - [x] 修正 junction、symlink、migration 與 evidence labeling 缺口
 - [x] 讓凍結 source revision 的 Windows、macOS、Linux CI 全部通過
-- [ ] 發布 prerelease，且只移動 `latest-v2`
+- [x] 發布 prerelease，且只移動 `latest-v2`
 - [x] 已在明確 quota authorization 下完成修正後的 36-attempt Behavior smoke
 - [x] 已審查 paired results，只發布有 attestation 且已去識別化的 evidence
 - [x] 已在 Windows、macOS、Linux 驗證 Plugin 與純 SKILL 的 release-archive contracts


### PR DESCRIPTION
## Summary

- mark the `v2.0.0-beta.2` roadmap milestone completed in English and Traditional Chinese
- record the published prerelease and `latest-v2` channel only after release workflow, checksum, provenance, Plugin, and Skill verification succeeded

## Verification

- [x] 21 release/documentation contract tests
- [x] Markdown link check
- [x] 60-page Astro build
- [x] `git diff --check`