### PR TITLE
fix(governance): align required GitHub check contexts

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -18,6 +18,28 @@
 - Model evaluation evidence status (`manual-required`, `review-required`, or `attested`):
 - Authorized model quota and attempt budget, if behavior evidence was produced:
 
+## Repository Governance
+
+- [ ] `.github/branch-protection.json` still matches the protected `main` branch.
+- [ ] Required checks use the Check Run display names, not workflow job IDs.
+- [ ] A pull request passed every required check and merged without an administrator bypass.
+
+The versioned contract currently requires these GitHub Actions checks:
+
+- `Core, documentation, and policy contracts`
+- `Site visual regression`
+
+Audit the live rule before a release:
+
+```bash
+gh api repos/eric861129/Workflow-skill-router/branches/main/protection \
+  --jq '.required_status_checks | {strict, checks}'
+```
+
+If a workflow job's display name changes, update the workflow and
+`.github/branch-protection.json` together, then update the live GitHub rule in the
+same pull request cycle.
+
 ## Supply Chain
 
 - [ ] Artifacts were built from the clean tagged source revision.

--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,21 @@
+{
+  "repository": "eric861129/Workflow-skill-router",
+  "branch": "main",
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      {
+        "workflow": ".github/workflows/validate.yml",
+        "job": "validate",
+        "context": "Core, documentation, and policy contracts",
+        "app_id": 15368
+      },
+      {
+        "workflow": ".github/workflows/validate.yml",
+        "job": "site-visual",
+        "context": "Site visual regression",
+        "app_id": 15368
+      }
+    ]
+  }
+}

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,3 +1,4 @@
+import json
 import re
 import unittest
 from pathlib import Path
@@ -7,10 +8,23 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 ACTION_PATTERN = re.compile(r"\buses:\s*([^@\s]+)@([^\s#]+)")
 FULL_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+JOB_BLOCK_PATTERN = re.compile(
+    r"(?ms)^  (?P<job>[A-Za-z0-9_-]+):\s*\n"
+    r"(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\s*\n|\Z)"
+)
 
 
 def workflow_text(name: str) -> str:
     return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+def workflow_job_names(name: str) -> dict[str, str]:
+    jobs: dict[str, str] = {}
+    for match in JOB_BLOCK_PATTERN.finditer(workflow_text(name)):
+        job_name = re.search(r"(?m)^    name:\s*(.+?)\s*$", match.group("body"))
+        if job_name:
+            jobs[match.group("job")] = job_name.group(1)
+    return jobs
 
 
 class GitHubWorkflowTests(unittest.TestCase):
@@ -123,6 +137,21 @@ class GitHubWorkflowTests(unittest.TestCase):
         for required in ('directory: "/site"', 'directory: "/plugins/workflow-skill-router"'):
             self.assertIn(required, content)
         self.assertIn('package-ecosystem: "github-actions"', content)
+
+    def test_branch_protection_contract_tracks_actual_check_run_names(self) -> None:
+        contract = json.loads(
+            (ROOT / ".github" / "branch-protection.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual("main", contract["branch"])
+        self.assertTrue(contract["required_status_checks"]["strict"])
+
+        required_checks = contract["required_status_checks"]["checks"]
+        self.assertEqual(2, len(required_checks))
+        for check in required_checks:
+            with self.subTest(job=check["job"]):
+                names = workflow_job_names(Path(check["workflow"]).name)
+                self.assertEqual(names[check["job"]], check["context"])
+                self.assertEqual(15368, check["app_id"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- align protected main with the Check Run display names emitted by GitHub Actions
- version the required-check contract in .github/branch-protection.json
- add a regression test and release checklist so workflow display-name drift is caught before release

## Root cause

Branch protection required the workflow job IDs alidate and site-visual, while GitHub emitted Core, documentation, and policy contracts and Site visual regression. CI passed, but the mismatched required contexts kept pull requests blocked.

## Verification

- python -m unittest discover -s tests -v (135 passed)
- python scripts/check-markdown-links.py .
- python scripts/audit-public-readiness.py .
- python scripts/build-release-artifacts.py --check
- git diff --check
- live branch-protection readback matches the versioned contract

## Merge proof

This PR must merge with the normal merge path after the required checks pass. Do not use an administrator bypass.